### PR TITLE
refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Generate meaningful commit messages and comprehensive pull request descriptions 
 
 ```bash
 # Install globally
-npm install -g pr-description-cli
+npm install -g gitvibe
 
 # Or with other package managers
-pnpm add -g pr-description-cli
-yarn global add pr-description-cli
-bun install -g pr-description-cli
+pnpm add -g gitvibe
+yarn global add gitvibe
+bun install -g gitvibe
 ```
 
 ### Initial Setup
@@ -182,14 +182,33 @@ providers:
         apiKey: "your-api-key" # Stored securely in system keychain
         defaultModel: "gpt-3.5-turbo"
         enabled: true
+        customModels: ["gpt-4o", "gpt-4o-mini"] # Add new models not in the built-in list
     anthropic:
         apiKey: "your-api-key"
         defaultModel: "claude-3-haiku-20240307"
         enabled: true
+        customModels: []
     google:
         apiKey: "your-api-key"
         defaultModel: "gemini-pro"
         enabled: true
+        customModels: []
+```
+
+#### Dynamic Model Support
+
+The CLI supports using new AI models as soon as they're released by providers, without requiring CLI updates:
+
+-   **Automatic Support**: Any model string is accepted - the AI SDK handles validation
+-   **Custom Models**: Add new models to your config using `customModels` array
+-   **Smart Warnings**: Unknown models trigger warnings with suggestions for similar known models
+
+```bash
+# Add a new model to your config
+gitvibe config set providers.openai.customModels "gpt-4o,gpt-4o-mini,gpt-4-turbo"
+
+# Use the new model immediately
+gitvibe commit --model gpt-4o
 ```
 
 ### Templates

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gitvibe-cli",
+  "name": "gitvibe",
   "version": "1.0.0",
   "description": "AI-powered CLI tool for generating commit messages and PR descriptions",
   "main": "dist/index.js",
@@ -22,6 +22,9 @@
     "commit",
     "pr",
     "ai",
+    "github",
+    "commit-message",
+    "pull-request",
     "llm",
     "openai",
     "anthropic",

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -161,6 +161,18 @@ async function showConfig(options: { json?: boolean }): Promise<void> {
   console.log(`  Commit templates: default, conventional${commitCustomCount > 0 ? `, +${commitCustomCount} custom` : ''}`);
   console.log(`  PR templates: default, detailed${prCustomCount > 0 ? `, +${prCustomCount} custom` : ''}`);
 
+  // Custom models section
+  const customModelCounts = Object.entries(config.providers)
+    .map(([provider, config]) => ({ provider, count: config.customModels?.length || 0 }))
+    .filter(({ count }) => count > 0);
+
+  if (customModelCounts.length > 0) {
+    console.log(chalk.yellow('\n🤖 Custom Models:'));
+    customModelCounts.forEach(({ provider, count }) => {
+      console.log(`  ${provider}: ${count} custom model(s)`);
+    });
+  }
+
   // Analytics section
   console.log(chalk.yellow('\n📊 Analytics:'));
   console.log(`  Enabled: ${config.analytics.enabled ? '✅' : '❌'}`);
@@ -194,6 +206,9 @@ async function setConfig(key: string, value: string, options: { provider?: strin
         config.providers[provider].defaultModel = value;
       } else if (providerKey === 'enabled') {
         config.providers[provider].enabled = value.toLowerCase() === 'true';
+      } else if (providerKey === 'customModels') {
+        // Allow comma-separated list of custom model IDs
+        config.providers[provider].customModels = value.split(',').map(m => m.trim()).filter(Boolean);
       } else {
         throw new Error(`Unknown provider setting: ${providerKey}`);
       }

--- a/src/core/config/manager.ts
+++ b/src/core/config/manager.ts
@@ -29,18 +29,22 @@ export class ConfigManager {
                 openai: {
                     defaultModel: "gpt-5-mini",
                     enabled: true,
+                    customModels: [],
                 },
                 anthropic: {
                     defaultModel: "claude-3-7-sonnet-latest",
                     enabled: true,
+                    customModels: [],
                 },
                 google: {
                     defaultModel: "gemini-2.5-flash",
                     enabled: true,
+                    customModels: [],
                 },
                 groq: {
                     defaultModel: "moonshotai/kimi-k2-instruct",
                     enabled: true,
+                    customModels: [],
                 },
             },
             templates: {

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -4,6 +4,7 @@ export const ProviderConfigSchema = z.object({
   apiKey: z.string().optional(),
   defaultModel: z.string(),
   enabled: z.boolean().default(true),
+  customModels: z.array(z.string()).default([]),
 });
 
 export const ProvidersConfigSchema = z.object({


### PR DESCRIPTION
## What Changed
- **Re-branded** the package from `pr-description-cli` → `gitvibe` (CLI name, README examples, package.json).
- **Added dynamic model support**: any model string is now accepted; unknown models trigger a warning with up-close suggestions.
- **New `customModels` array** in every provider config. Users can extend the built-in model list without waiting for a CLI release.
- **CLI `config` commands** grew a `providers.<name>.customModels` key that accepts a comma-separated list.
- **Default models bumped** to the latest shipping versions (GPT-5-mini, Claude-3-7-sonnet, Gemini-2.5-flash, Kimi-k2).
- **README** expanded with a “Dynamic Model Support” section and live examples of adding/using new models.
- **Minor enhancements**: `gitvibe config` now prints a “Custom Models” summary line when present.

## Why
- **Agility**: AI providers release new models weekly; hard-coded lists force users to upgrade the CLI for every new model.
- **User control**: Teams often run fine-tuned or beta models that will never appear in a static allow-list.
- **Re-branding**: “gitvibe” is shorter, memorable, and reflects the tool’s Git-centric, vibe-driven workflow.

## Testing
1. `npm install -g gitvibe` (or `yarn global add gitvibe`, etc.) → verify binary is available as `gitvibe`.
2. `gitvibe config set providers.openai.customModels "gpt-4o,gpt-4o-mini,gpt-4-turbo"` → check that `gitvibe config` lists the three custom models under “🤖 Custom Models”.
3. `gitvibe commit --model gpt-4o` → confirm warning-free operation (if `gpt-4o` is unknown to the built-in list you’ll see a warning + suggestions).
4. Introduce a typo: `gitvibe commit --model gpt-4o-min` → expect a warning listing close matches.
5. Regression: existing workflows using built-in models (e.g. `--model gpt-4`) continue to work without warnings.