### PR TITLE
keychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,21 +179,20 @@ The CLI stores configuration in `~/.gitvibe/config.yaml`. The configuration incl
 ```yaml
 providers:
     openai:
-        apiKey: "your-api-key" # Stored securely in system keychain
         defaultModel: "gpt-3.5-turbo"
         enabled: true
         customModels: ["gpt-4o", "gpt-4o-mini"] # Add new models not in the built-in list
     anthropic:
-        apiKey: "your-api-key"
         defaultModel: "claude-3-haiku-20240307"
         enabled: true
         customModels: []
     google:
-        apiKey: "your-api-key"
         defaultModel: "gemini-pro"
         enabled: true
         customModels: []
 ```
+
+**Note:** API keys are stored securely in the system keychain and are not included in the YAML configuration file.
 
 #### Dynamic Model Support
 

--- a/src/core/ai/generator.ts
+++ b/src/core/ai/generator.ts
@@ -86,7 +86,7 @@ export class AIGenerator {
     const template = this.getTemplate('commit', options.template);
     const prompt = this.buildPrompt(template, { diff: gitDiff });
 
-    const model = this.providerManager.getModel(options.provider, options.model);
+    const model = await this.providerManager.getModel(options.provider, options.model);
     const maxOutputTokens = options.maxOutputTokens || this.config.options.maxOutputTokens;
     const temperature = options.temperature || this.config.options.temperature;
 
@@ -123,7 +123,7 @@ export class AIGenerator {
     const template = this.getTemplate('commit', options.template);
     const prompt = this.buildPrompt(template, { diff: gitDiff });
 
-    const model = this.providerManager.getModel(options.provider, options.model);
+    const model = await this.providerManager.getModel(options.provider, options.model);
     const maxOutputTokens = options.maxOutputTokens || this.config.options.maxOutputTokens;
     const temperature = options.temperature || this.config.options.temperature;
 
@@ -179,7 +179,7 @@ ${combinedSummaries}
 
 Please create a cohesive PR description that covers all the changes mentioned in the summaries.`;
 
-    const model = this.providerManager.getModel(options.provider, options.model);
+    const model = await this.providerManager.getModel(options.provider, options.model);
     const maxOutputTokens = options.maxOutputTokens || this.config.options.maxOutputTokens;
     const temperature = options.temperature || this.config.options.temperature;
 
@@ -206,7 +206,7 @@ Please create a cohesive PR description that covers all the changes mentioned in
     const template = this.getTemplate('pr', options.template);
     const prompt = this.buildPrompt(template, { diff: gitDiff });
 
-    const model = this.providerManager.getModel(options.provider, options.model);
+    const model = await this.providerManager.getModel(options.provider, options.model);
     const maxOutputTokens = options.maxOutputTokens || this.config.options.maxOutputTokens;
     const temperature = options.temperature || this.config.options.temperature;
 
@@ -244,7 +244,7 @@ Please create a cohesive PR description that covers all the changes mentioned in
     const template = this.getTemplate('pr', options.template);
     const prompt = this.buildPrompt(template, { diff: gitDiff });
 
-    const model = this.providerManager.getModel(options.provider, options.model);
+    const model = await this.providerManager.getModel(options.provider, options.model);
     const maxOutputTokens = options.maxOutputTokens || this.config.options.maxOutputTokens;
     const temperature = options.temperature || this.config.options.temperature;
 
@@ -299,7 +299,7 @@ Please create a cohesive PR description that covers all the changes mentioned in
 
   public async testConnection(provider?: string, model?: string): Promise<boolean> {
     try {
-      const testModel = this.providerManager.getModel(provider, model);
+      const testModel = await this.providerManager.getModel(provider, model);
       await generateText({
         model: testModel,
         prompt: 'Hello',

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 export const ProviderConfigSchema = z.object({
-  apiKey: z.string().optional(),
   defaultModel: z.string(),
   enabled: z.boolean().default(true),
   customModels: z.array(z.string()).default([]),


### PR DESCRIPTION
## What Changed
- **Secure API key storage**: Moved all provider API keys out of the plain-text `config.yaml` and into the OS keychain via the `keytar` library.  
- **Transparent migration**: On first load, any existing API keys in the config file are automatically migrated to the keychain and then removed from the file.  
- **Updated CLI commands**:  
  – `init` now prompts for two new chunking options (`maxDiffSize`, `chunkOverlap`) and stores the API key in the keychain.  
  – `config set providers.<name>.apiKey` stores the key in the keychain instead of the YAML file.  
  – `config get providers.<name>.apiKey` retrieves the masked key from the keychain.  
  – `config show` and `validate` reflect keychain status (🔑 / 🚫).  
- **Provider layer refactored**: `AIProviderManager` is now async; `getModel` and `isProviderConfigured` fetch the key from the keychain at runtime.  
- **Schema & docs**: Removed `apiKey` from the YAML schema and updated README to clarify keychain usage.  
- **Test coverage**: Added unit tests for keychain CRUD operations.

## Why
Storing secrets in plain text is a security anti-pattern. By leveraging the OS keychain we:
- Eliminate the risk of accidental commits or exposure of API keys.  
- Allow users to share their `config.yaml` safely.  
- Align with security best-practices without breaking existing workflows.

## Testing
1. Check out the branch and run `npm install` (new dependency: `keytar`).  
2. If you have an existing `~/.gitvibe/config.yaml` with `apiKey` fields, start any command (e.g. `gitvibe config validate`) and verify:  
   - Keys disappear from the file.  
   - `config show` displays 🔑 for migrated providers.  
3. Run `gitvibe init --provider openai` and enter a new key; confirm it is **not** written to the config file but commands still work.  
4. `gitvibe config get providers.openai.apiKey` should print the masked key.  
5. `gitvibe config validate` should pass when at least one provider has a key in the keychain and is enabled.  
6. Run